### PR TITLE
Check dynamic methods for conflicts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    enumbler (0.8.0)
+    enumbler (0.8.1)
       activerecord (>= 5.2.3, < 6.1)
       activesupport (>= 5.2.3, < 6.1)
 

--- a/README.md
+++ b/README.md
@@ -170,13 +170,11 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Roadmap
 
-* We need to add in support for additional attributes/columns in the enumbled table.  For example, following the `Color` concept, we may want to have a column which is `hex` and stores the colors `hex` value (e.g., `FFFFFF`).  This should be supported.
-* Ideally, we could make this work more like a traditional `enum`; for example, overriding the `.where` method by allowing something like: `House.where(color: :blue)` instead of `House.where_color(:blue)`.  But right now am in a rush and not sure how to go about doing that properly.
+* Ideally, we could make this work more like a traditional `enum`; for example, overriding the `.where` method by allowing something like: `House.where(color: :blue)` instead of `House.color(:blue)`.  But right now am in a rush and not sure how to go about doing that properly.
 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/linguabee/enumbler.
-
 
 ## License
 

--- a/lib/enumbler/version.rb
+++ b/lib/enumbler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Enumbler
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/spec/enumbler_spec.rb
+++ b/spec/enumbler_spec.rb
@@ -110,13 +110,36 @@ RSpec.describe Enumbler do
     it 'raises an error when the same enumble is added twice' do
       expect { Color.enumble(:white, 1) }.to raise_error(Enumbler::Error, /twice/)
     end
+
     it 'raises an error when no numeric id is passed as the second argument' do
       expect { Color.enumble(:white, label: 'error') }.to raise_error(Enumbler::Error, /numeric/)
     end
+
+    it 'raises an error when there is a class method naming conflict' do
+      expect do
+        Class.new(ApplicationRecord) do
+          include Enumbler::Enabler
+
+          enumble :transaction, 1
+        end
+      end.to raise_error(Enumbler::Error, /class method `transaction`/)
+    end
+
+    it 'raises an error when there is a instance method naming conflict' do
+      expect do
+        Class.new(ApplicationRecord) do
+          include Enumbler::Enabler
+
+          enumble :persisted, 1
+        end
+      end.to raise_error(Enumbler::Error, /instance method `persisted\?`/)
+    end
+
     it 'creates the constants' do
       expect(Color::BLACK).to eq 1
       expect(Color::WHITE).to eq 2
     end
+
     it 'creates the class finder methods', :seed do
       expect(Color.black).to eq Color.find(Color::BLACK)
     end


### PR DESCRIPTION
Ran into an issue naming an enumble `transaction` which conflicts with `ActiveRecord.transaction` only there wasn't any indication of the conflict but had adverse seemingly miraculous side effects. Hopefully this will prevent future generations from suffering as I have suffered.
