### PR TITLE
Allow .find_enumbles to take an Enumbler::Enumble

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    enumbler (0.8.1)
+    enumbler (0.8.2)
       activerecord (>= 5.2.3, < 6.1)
       activesupport (>= 5.2.3, < 6.1)
 

--- a/lib/enumbler/enabler.rb
+++ b/lib/enumbler/enabler.rb
@@ -227,6 +227,8 @@ module Enumbler
             enumble =
               if arg.is_a?(Symbol)
                 @enumbled_model.enumbles.find { |e| e.enum == arg }
+              elsif arg.is_a?(Enumbler::Enumble)
+                @enumbled_model.enumbles.find { |e| e.enum == arg.enum }
               elsif arg.is_a?(String)
                 @enumbled_model.enumbles.find do |e|
                   if case_sensitive

--- a/lib/enumbler/version.rb
+++ b/lib/enumbler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Enumbler
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end

--- a/spec/enumbler_spec.rb
+++ b/spec/enumbler_spec.rb
@@ -322,11 +322,14 @@ RSpec.describe Enumbler do
     it 'returns the correct enumbles' do
       expect(Color.find_enumbles(1, 2)).to contain_exactly(Color.enumbles.first, Color.enumbles.second)
       expect(Color.find_enumble(1)).to eq Color.enumbles.first
+      expect(Color.find_enumble(Color.enumbles.first)).to eq Color.enumbles.first
     end
+
     it 'can return an enumble based on a ActiveModel record' do
       color = Color.find(1)
       expect(Color.find_enumbles!(color)).to contain_exactly(color.enumble)
     end
+
     it 'raises an error when something that is not an integer is passed' do
       expect { Color.find_enumbles('bob') }.not_to raise_error
       expect { Color.find_enumbles!('bob') }.to raise_error(Enumbler::Error, /bob/)


### PR DESCRIPTION
The `.find_enumbles` method is meant to be flexible accepting a range of argument types indescrimintly.  Just found a situation where I was passing one enumble to another and hitting an error.
